### PR TITLE
Fix purple constant not being purple

### DIFF
--- a/main.js
+++ b/main.js
@@ -55,7 +55,7 @@ var EquationColor;
     EquationColor["YELLOW"] = "#ffff00";
     EquationColor["MAGENTA"] = "#ff00ff";
     EquationColor["CYAN"] = "#00ffff";
-    EquationColor["PURPLE"] = "#cc8899";
+    EquationColor["PURPLE"] = "#6042a6";
     EquationColor["ORANGE"] = "#ffa500";
     EquationColor["BLACK"] = "#000000";
     EquationColor["WHITE"] = "#ffffff";

--- a/src/dsl.ts
+++ b/src/dsl.ts
@@ -46,7 +46,7 @@ export enum EquationColor {
     MAGENTA = "#ff00ff",
     CYAN = "#00ffff",
 
-    PURPLE = "#cc8899",
+    PURPLE = "#6042a6",
     ORANGE = "#ffa500",
     BLACK = "#000000",
     WHITE = "#ffffff",


### PR DESCRIPTION
Changes the hex code of the `purple` colour constant from `#cc8899` -> `#6042a6`

Fixes #39 