### PR TITLE
Implement legacy API version toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,4 +169,4 @@ For instance, if you wanted all graphs to be centered in the page content, you c
 # Offline Usage
 
 If you've rendered at least one graph while connected to the internet then any future graphs (irrespective of the cache setting) should be able to render (if they don't then make an issue here).  
-*Requires enable legacy API mode in the plugin settings.
+*Requires enabling legacy API mode in the plugin settings.

--- a/README.md
+++ b/README.md
@@ -168,4 +168,5 @@ For instance, if you wanted all graphs to be centered in the page content, you c
 
 # Offline Usage
 
-If you've rendered at least one graph while connected to the internet then any future graphs (irrespective of the cache setting) should be able to render (if they don't then make an issue here).
+If you've rendered at least one graph while connected to the internet then any future graphs (irrespective of the cache setting) should be able to render (if they don't then make an issue here).  
+*Requires enable legacy API mode in the plugin settings.

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -115,7 +115,7 @@ export class Renderer {
         }
 
         // Because of the electron sandboxing we have to do this inside an iframe (and regardless this is safer)
-        let api_version = settings.use_legacy_desmos_api ? "v1.5" : "v1.6";
+        const api_version = settings.use_legacy_desmos_api ? "v1.5" : "v1.6";
         const htmlHead = `<script id="desmos-api" src="https://www.desmos.com/api/${api_version}/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"></script>`;
         const htmlBody = `
             <div id="calculator-${hash}" style="width: ${graphSettings.width}px; height: ${

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -114,11 +114,9 @@ export class Renderer {
             expressions.push(`calculator.setExpression(JSON.parse(${JSON.stringify(JSON.stringify(expression))}));`);
         }
 
-        // Because of the electron sandboxing we have to do this inside an iframe (and regardless this is safer),
-        //   otherwise we can't include the desmos API (although it would be nice if they had a REST API of some sort)
-        // Interestingly enough, this script functions perfectly fine fully offline - so we could include a vendored copy if need be
-        //   (the script gets cached by electron the first time it's used so this isn't a particularly high priority)
-        const htmlHead = `<script src="https://www.desmos.com/api/v1.6/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"></script>`;
+        // Because of the electron sandboxing we have to do this inside an iframe (and regardless this is safer)
+        let api_version = settings.use_legacy_desmos_api ? "v1.5" : "v1.6";
+        const htmlHead = `<script id="desmos-api" src="https://www.desmos.com/api/${api_version}/calculator.js?apiKey=dcb31709b452b1cf9dc26972add0fda6"></script>`;
         const htmlBody = `
             <div id="calculator-${hash}" style="width: ${graphSettings.width}px; height: ${
             graphSettings.height

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,7 +42,7 @@ export function DEFAULT_SETTINGS(plugin: Desmos): Settings {
 /** Attempt to migrate the given settings object to the current structure */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function migrateSettings(plugin: Desmos, settings: any): Settings {
-    if (!settings.hasOwnProperty("use_legacy_desmos_api")) {
+    if (!Object.prototype.hasOwnProperty.call(settings, "use_legacy_desmos_api")) {
         settings.use_legacy_desmos_api = DEFAULT_SETTINGS_STATIC.use_legacy_desmos_api;
     }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,8 @@ export enum CacheLocation {
 export interface Settings {
     /** The program version these settings were created in */
     version: string;
+    /** Whether to use an older version of the Desmos API (v1.5), this is required for offline mode to work */
+    use_legacy_desmos_api: boolean;
     // /** The debounce timer (in ms) */
     // debounce: number;
     cache: CacheSettings;
@@ -22,6 +24,7 @@ export interface CacheSettings {
 
 const DEFAULT_SETTINGS_STATIC: Omit<Settings, "version"> = {
     // debounce: 500,
+    use_legacy_desmos_api: false,
     cache: {
         enabled: true,
         location: CacheLocation.Memory,
@@ -37,8 +40,12 @@ export function DEFAULT_SETTINGS(plugin: Desmos): Settings {
 }
 
 /** Attempt to migrate the given settings object to the current structure */
-export function migrateSettings(plugin: Desmos, settings: object): Settings {
-    // todo (there is currently only one version of the settings interface)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function migrateSettings(plugin: Desmos, settings: any): Settings {
+    if (!settings.hasOwnProperty("use_legacy_desmos_api")) {
+        settings.use_legacy_desmos_api = DEFAULT_SETTINGS_STATIC.use_legacy_desmos_api;
+    }
+
     return settings as Settings;
 }
 
@@ -114,5 +121,20 @@ export class SettingsTab extends PluginSettingTab {
                     });
             }
         }
+
+        new Setting(containerEl)
+            .setName("Use Legacy Desmos API")
+            .setDesc(
+                "Whether to use a legacy version (v1.5) of the Desmos API over the current latest version, this must be enabled for offline usage to work as versions >1.5 require an internet connection. Enabling this will prevent any features from later versions from functioning correctly."
+            )
+            .addToggle((toggle) =>
+                toggle.setValue(this.plugin.settings.use_legacy_desmos_api).onChange(async (value) => {
+                    this.plugin.settings.use_legacy_desmos_api = value;
+                    await this.plugin.saveSettings();
+
+                    // Reset the display so the new state can render
+                    this.display();
+                })
+            );
     }
 }


### PR DESCRIPTION
Implements a toggle to downgrade the Desmos API version to v1.5, this is required for offline mode to work as future versions need an internet connection. 

Fixes #88 