### PR TITLE
Improve graph caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ Download the attached files from the [latest release](https://github.com/Nigecat
 
 # Exporting
 
-If you wish to export a note with a graph in it to a pdf then **caching must be enabled and the graph(s) must be in the cache** (meaning you've viewed it at least once) - as however Obsidian is doing the pdf export causes the Desmos API to break and never return a rendered graph.  
+If you wish to export a note with a graph in it to a pdf then   
+(a) Filesystem caching must be on  
+(b) All target graphs must be in the filesystem cache
+(c) The renderer must be disabled  
+(a) and (c) can be found in the plugin settings. (b) can be achieved by viewing all graphs at least once after enabling filesystem caching.
 
 # Usage
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,6 +75,10 @@ export default class Desmos extends Plugin {
             return await (await fetch(api)).text();
         }
 
+        if (this.desmosApiCache != null) {
+            return this.desmosApiCache;
+        }
+
         const dir = normalizePath(`.obsidian/plugins/${this.manifest.id}/vendor`);
         if (!(await app.vault.adapter.exists(dir))) {
             await app.vault.adapter.mkdir(dir);

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -71,6 +71,13 @@ export class Renderer {
             }
         }
 
+        if (!plugin.settings.renderer) {
+            // If the renderer is disabled, throw an error
+            throw new Error(
+                "Unable to render a new graph with the renderer disabled. Set the 'Renderer' option to true in the plugin config (requires filesystem caching) to allow rendering new graphs again. If you're trying to export, all graphs must be in the graph cache (meaning they must have been viewd before the renderer was disabled)."
+            );
+        }
+
         // Parse equations into a series of Desmos expressions
         const expressions: string[] = [];
         for (const equation of equations) {


### PR DESCRIPTION
This improves some internals relating to graph caching, and also introduces an option to completely disable the renderer. 
![image](https://github.com/Nigecat/obsidian-desmos/assets/48661288/d3f3136f-30a8-40b5-98ea-ed78c45bf229)

Closes #107 
